### PR TITLE
refactor: renomear colunas e métodos na classe Cultura e atualizar ló…

### DIFF
--- a/SpringBootSIVAP/sivap/src/main/java/br/uel/trabalho/sivap/dao/PgCulturaDAO.java
+++ b/SpringBootSIVAP/sivap/src/main/java/br/uel/trabalho/sivap/dao/PgCulturaDAO.java
@@ -18,10 +18,10 @@ public class PgCulturaDAO implements CulturaDAO {
 
     @Override
     public Cultura inserir(Cultura cultura) throws SQLException, IOException, ClassNotFoundException {
-        String sql = "INSERT INTO cultura (nome) VALUES (?)";
+        String sql = "INSERT INTO cultura (nome_cultura) VALUES (?)";
         try (Connection conn = dataSource.getConnection();
              PreparedStatement pst = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
-            pst.setString(1, cultura.getNome());
+            pst.setString(1, cultura.getNome_cultura());
             pst.executeUpdate();
             try (ResultSet rs = pst.getGeneratedKeys()) {
                 if (rs.next()) {
@@ -33,16 +33,16 @@ public class PgCulturaDAO implements CulturaDAO {
     }
 
     @Override
-    public Cultura buscaPorId(int id) throws SQLException, IOException, ClassNotFoundException {
-        String sql = "SELECT id, nome FROM cultura WHERE id = ?";
+    public Cultura buscaPorId(int id_cultura) throws SQLException, IOException, ClassNotFoundException {
+        String sql = "SELECT id_cultura, nome_cultura FROM cultura WHERE id_cultura = ?";
         Cultura cultura = null;
         try (Connection conn = dataSource.getConnection();
              PreparedStatement pst = conn.prepareStatement(sql)) {
-            pst.setInt(1, id);
+            pst.setInt(1, id_cultura);
             try (ResultSet rs = pst.executeQuery()) {
                 if (rs.next()) {
-                    String nome = rs.getString("nome");
-                    cultura = new Cultura(id, nome);
+                    String nome_cultura = rs.getString("nome_cultura");
+                    cultura = new Cultura(id_cultura, nome_cultura);
                 }
             }
         }
@@ -51,15 +51,15 @@ public class PgCulturaDAO implements CulturaDAO {
 
     @Override
     public List<Cultura> listarTodos() throws SQLException, IOException, ClassNotFoundException {
-        String sql = "SELECT id, nome FROM cultura ORDER BY nome";
+        String sql = "SELECT id_cultura, nome_cultura FROM cultura ORDER BY nome_cultura";
         List<Cultura> culturas = new ArrayList<>();
         try (Connection conn = dataSource.getConnection();
              Statement st = conn.createStatement();
              ResultSet rs = st.executeQuery(sql)) {
             while (rs.next()) {
-                int id = rs.getInt("id");
-                String nome = rs.getString("nome");
-                culturas.add(new Cultura(id, nome));
+                int id_cultura = rs.getInt("id_cultura");
+                String nome_cultura = rs.getString("nome_cultura");
+                culturas.add(new Cultura(id_cultura, nome_cultura));
             }
         }
         return culturas;
@@ -67,21 +67,21 @@ public class PgCulturaDAO implements CulturaDAO {
 
     @Override
     public void atualizar(Cultura cultura) throws SQLException, IOException, ClassNotFoundException {
-        String sql = "UPDATE cultura SET nome = ? WHERE id = ?";
+        String sql = "UPDATE cultura SET nome_cultura = ? WHERE id_cultura = ?";
         try (Connection conn = dataSource.getConnection();
              PreparedStatement pst = conn.prepareStatement(sql)) {
-            pst.setString(1, cultura.getNome());
-            pst.setInt(2, cultura.getId());
+            pst.setString(1, cultura.getNome_cultura());
+            pst.setInt(2, cultura.getId_cultura());
             pst.executeUpdate();
         }
     }
 
     @Override
-    public void deletar(int id) throws SQLException, IOException, ClassNotFoundException {
-        String sql = "DELETE FROM cultura WHERE id = ?";
+    public void deletar(int id_cultura) throws SQLException, IOException, ClassNotFoundException {
+        String sql = "DELETE FROM cultura WHERE id_cultura = ?";
         try (Connection conn = dataSource.getConnection();
              PreparedStatement pst = conn.prepareStatement(sql)) {
-            pst.setInt(1, id);
+            pst.setInt(1, id_cultura);
             pst.executeUpdate();
         }
     }

--- a/SpringBootSIVAP/sivap/src/main/java/br/uel/trabalho/sivap/model/Cultura.java
+++ b/SpringBootSIVAP/sivap/src/main/java/br/uel/trabalho/sivap/model/Cultura.java
@@ -9,7 +9,7 @@ public class Cultura {
         this.nome = nome;
     }
 
-    public int getId() {
+    public int getId_cultura() {
         return id;
     }
 
@@ -17,11 +17,11 @@ public class Cultura {
         this.id = id;
     }
 
-    public String getNome() {
+    public String getNome_cultura() {
         return nome;
     }
 
-    public void setNome(String nome) {
+    public void setNome_cultura(String nome) {
         this.nome = nome;
     }
 

--- a/SpringBootSIVAP/sivap/src/test/java/br/uel/trabalho/sivap/DAOTest.java
+++ b/SpringBootSIVAP/sivap/src/test/java/br/uel/trabalho/sivap/DAOTest.java
@@ -1,0 +1,227 @@
+package br.uel.trabalho.sivap;
+
+import br.uel.trabalho.sivap.dao.*;
+import br.uel.trabalho.sivap.model.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.Random;
+
+@SpringBootTest
+@Transactional // Garante rollback após cada teste
+public class DAOTest {
+    @Autowired
+    private PgProdutorRuralDAO produtorRuralDAO;
+    @Autowired
+    private PgPropriedadeDAO propriedadeDAO;
+    @Autowired
+    private PgCulturaDAO culturaDAO;
+    @Autowired
+    private PgVariedadeCulturaDAO variedadeCulturaDAO;
+    @Autowired
+    private PgTalhaoDAO talhaoDAO;
+    @Autowired
+    private PgSafraDAO safraDAO;
+    @Autowired
+    private PgCondicaoClimaticaDAO condicaoClimaticaDAO;
+
+    private final Random random = new Random();
+
+    private String gerarNomeUnico(String prefixo) {
+        return prefixo + "_" + System.currentTimeMillis() % 10000;
+    }
+
+    private String gerarNomeCulturaUnico(String prefixo) {
+        // Limita a 30 caracteres para o campo nome_cultura
+        String nome = prefixo + "_" + System.currentTimeMillis() % 1000;
+        return nome.length() > 30 ? nome.substring(0, 30) : nome;
+    }
+
+    private BigDecimal gerarCoordenadaUnica(double min, double max) {
+        return new BigDecimal(String.valueOf(min + random.nextDouble() * (max - min)));
+    }
+
+    @Test
+    void testCRUDProdutorRural() throws Exception {
+        // Criação
+        String cpfUnico = "999" + System.currentTimeMillis() % 100000000;
+        ProdutorRural produtor = new ProdutorRural(cpfUnico, gerarNomeUnico("Teste Produtor"), 'm', new Date());
+        produtorRuralDAO.inserir(produtor);
+        // Leitura
+        ProdutorRural encontrado = produtorRuralDAO.buscarPorCpf(cpfUnico);
+        Assertions.assertNotNull(encontrado);
+        Assertions.assertEquals(produtor.getNome(), encontrado.getNome());
+        // Atualização
+        encontrado.setNome(gerarNomeUnico("Produtor Atualizado"));
+        produtorRuralDAO.atualizar(encontrado);
+        ProdutorRural atualizado = produtorRuralDAO.buscarPorCpf(cpfUnico);
+        Assertions.assertEquals(encontrado.getNome(), atualizado.getNome());
+        // Deleção
+        produtorRuralDAO.deletar(cpfUnico);
+        Assertions.assertNull(produtorRuralDAO.buscarPorCpf(cpfUnico));
+    }
+
+    @Test
+    void testCRUDPropriedade() throws Exception {
+        String nomeUnico = gerarNomeUnico("Fazenda Teste");
+        BigDecimal lat = gerarCoordenadaUnica(-25.0, -20.0);
+        BigDecimal lon = gerarCoordenadaUnica(-55.0, -50.0);
+        
+        Propriedade prop = new Propriedade(0, nomeUnico, lat, lon, new BigDecimal("100.0"));
+        propriedadeDAO.inserir(prop);
+        Propriedade encontrada = propriedadeDAO.buscaPorId(prop.getId());
+        Assertions.assertNotNull(encontrada);
+        Assertions.assertEquals(nomeUnico, encontrada.getNome());
+        encontrada.setNome(gerarNomeUnico("Fazenda Atualizada"));
+        propriedadeDAO.atualizar(encontrada);
+        Propriedade atualizada = propriedadeDAO.buscaPorId(prop.getId());
+        Assertions.assertEquals(encontrada.getNome(), atualizada.getNome());
+        propriedadeDAO.deletar(prop.getId());
+        Assertions.assertNull(propriedadeDAO.buscaPorId(prop.getId()));
+    }
+
+    @Test
+    void testCRUDCultura() throws Exception {
+        String nomeUnico = gerarNomeCulturaUnico("Cultura Teste");
+        Cultura cultura = new Cultura(0, nomeUnico);
+        culturaDAO.inserir(cultura);
+        Cultura encontrada = culturaDAO.buscaPorId(cultura.getId_cultura());
+        Assertions.assertNotNull(encontrada);
+        Assertions.assertEquals(nomeUnico, encontrada.getNome_cultura());
+        encontrada.setNome_cultura(gerarNomeCulturaUnico("Cultura Atualizada"));
+        culturaDAO.atualizar(encontrada);
+        Cultura atualizada = culturaDAO.buscaPorId(cultura.getId_cultura());
+        Assertions.assertEquals(encontrada.getNome_cultura(), atualizada.getNome_cultura());
+        culturaDAO.deletar(cultura.getId_cultura());
+        Assertions.assertNull(culturaDAO.buscaPorId(cultura.getId_cultura()));
+    }
+
+    @Test
+    void testCRUDVariedadeCultura() throws Exception {
+        // Primeiro, criar uma cultura para a FK
+        String nomeCulturaUnico = gerarNomeCulturaUnico("Cultura para Variedade");
+        Cultura cultura = new Cultura(0, nomeCulturaUnico);
+        culturaDAO.inserir(cultura);
+        
+        String descricaoUnica = gerarNomeUnico("Variedade Teste");
+        VariedadeCultura variedade = new VariedadeCultura(0, cultura.getId_cultura(), descricaoUnica, (short)5, (short)6, 90, (short)8);
+        variedadeCulturaDAO.inserir(variedade);
+        VariedadeCultura encontrada = variedadeCulturaDAO.buscaPorId(variedade.getId_variedade_cultura());
+        Assertions.assertNotNull(encontrada);
+        Assertions.assertEquals(descricaoUnica, encontrada.getDescricao());
+        encontrada.setDescricao(gerarNomeUnico("Variedade Atualizada"));
+        variedadeCulturaDAO.atualizar(encontrada);
+        VariedadeCultura atualizada = variedadeCulturaDAO.buscaPorId(variedade.getId_variedade_cultura());
+        Assertions.assertEquals(encontrada.getDescricao(), atualizada.getDescricao());
+        variedadeCulturaDAO.deletar(variedade.getId_variedade_cultura());
+        Assertions.assertNull(variedadeCulturaDAO.buscaPorId(variedade.getId_variedade_cultura()));
+        culturaDAO.deletar(cultura.getId_cultura()); // Limpeza
+    }
+
+    @Test
+    void testCRUDTalhao() throws Exception {
+        // Primeiro, criar uma propriedade para a FK
+        String nomePropUnico = gerarNomeUnico("Propriedade Talhao");
+        BigDecimal lat = gerarCoordenadaUnica(-25.0, -20.0);
+        BigDecimal lon = gerarCoordenadaUnica(-55.0, -50.0);
+        
+        Propriedade prop = new Propriedade(0, nomePropUnico, lat, lon, new BigDecimal("50.0"));
+        propriedadeDAO.inserir(prop);
+        Talhao talhao = new Talhao(prop.getId(), 0, new BigDecimal("20.0"));
+        talhaoDAO.inserir(talhao);
+        Talhao encontrado = talhaoDAO.buscaPorId(prop.getId(), talhao.getId_talhao());
+        Assertions.assertNotNull(encontrado);
+        Assertions.assertEquals(0, new BigDecimal("20.0").compareTo(encontrado.getArea()));
+        encontrado.setArea(new BigDecimal("25.0"));
+        talhaoDAO.atualizar(encontrado);
+        Talhao atualizado = talhaoDAO.buscaPorId(prop.getId(), talhao.getId_talhao());
+        Assertions.assertEquals(0, new BigDecimal("25.0").compareTo(atualizado.getArea()));
+        talhaoDAO.deletar(prop.getId(), talhao.getId_talhao());
+        Assertions.assertNull(talhaoDAO.buscaPorId(prop.getId(), talhao.getId_talhao()));
+        propriedadeDAO.deletar(prop.getId()); // Limpeza
+    }
+
+    @Test
+    void testCRUDSafra() throws Exception {
+        // Criar dependências: propriedade, talhao, cultura, variedade
+        String nomePropUnico = gerarNomeUnico("Propriedade Safra");
+        BigDecimal lat = gerarCoordenadaUnica(-25.0, -20.0);
+        BigDecimal lon = gerarCoordenadaUnica(-55.0, -50.0);
+        
+        Propriedade prop = new Propriedade(0, nomePropUnico, lat, lon, new BigDecimal("60.0"));
+        propriedadeDAO.inserir(prop);
+        Talhao talhao = new Talhao(prop.getId(), 0, new BigDecimal("30.0"));
+        talhaoDAO.inserir(talhao);
+        
+        String nomeCulturaUnico = gerarNomeCulturaUnico("Cultura Safra");
+        Cultura cultura = new Cultura(0, nomeCulturaUnico);
+        culturaDAO.inserir(cultura);
+        
+        String descricaoVariedadeUnica = gerarNomeUnico("Variedade Safra");
+        VariedadeCultura variedade = new VariedadeCultura(0, cultura.getId_cultura(), descricaoVariedadeUnica, (short)7, (short)7, 100, (short)9);
+        variedadeCulturaDAO.inserir(variedade);
+        
+        Safra safra = new Safra(0, prop.getId(), talhao.getId_talhao(), variedade.getId_variedade_cultura(), new Date(), new Date(), new BigDecimal("1000.0"));
+        safraDAO.inserir(safra);
+        Safra encontrada = safraDAO.buscaPorId(safra.getId_safra());
+        Assertions.assertNotNull(encontrada);
+        Assertions.assertEquals(0, new BigDecimal("1000.0").compareTo(encontrada.getProducao()));
+        encontrada.setProducao(new BigDecimal("1100.0"));
+        safraDAO.atualizar(encontrada);
+        Safra atualizada = safraDAO.buscaPorId(safra.getId_safra());
+        Assertions.assertEquals(0, new BigDecimal("1100.0").compareTo(atualizada.getProducao()));
+        safraDAO.deletar(safra.getId_safra());
+        Assertions.assertNull(safraDAO.buscaPorId(safra.getId_safra()));
+        variedadeCulturaDAO.deletar(variedade.getId_variedade_cultura());
+        culturaDAO.deletar(cultura.getId_cultura());
+        talhaoDAO.deletar(prop.getId(), talhao.getId_talhao());
+        propriedadeDAO.deletar(prop.getId());
+    }
+
+    @Test
+    void testCRUDCondicaoClimatica() throws Exception {
+        // Criar dependências: propriedade, talhao, cultura, variedade, safra
+        String nomePropUnico = gerarNomeUnico("Propriedade Clima");
+        BigDecimal lat = gerarCoordenadaUnica(-25.0, -20.0);
+        BigDecimal lon = gerarCoordenadaUnica(-55.0, -50.0);
+        
+        Propriedade prop = new Propriedade(0, nomePropUnico, lat, lon, new BigDecimal("70.0"));
+        propriedadeDAO.inserir(prop);
+        Talhao talhao = new Talhao(prop.getId(), 0, new BigDecimal("40.0"));
+        talhaoDAO.inserir(talhao);
+        
+        String nomeCulturaUnico = gerarNomeCulturaUnico("Cultura Clima");
+        Cultura cultura = new Cultura(0, nomeCulturaUnico);
+        culturaDAO.inserir(cultura);
+        
+        String descricaoVariedadeUnica = gerarNomeUnico("Variedade Clima");
+        VariedadeCultura variedade = new VariedadeCultura(0, cultura.getId_cultura(), descricaoVariedadeUnica, (short)8, (short)8, 110, (short)10);
+        variedadeCulturaDAO.inserir(variedade);
+        
+        Safra safra = new Safra(0, prop.getId(), talhao.getId_talhao(), variedade.getId_variedade_cultura(), new Date(), new Date(), new BigDecimal("2000.0"));
+        safraDAO.inserir(safra);
+        
+        String observacaoUnica = gerarNomeUnico("Observação Teste");
+        CondicaoClimatica cond = new CondicaoClimatica(0, safra.getId_safra(), new BigDecimal("500.0"), (short)9, new BigDecimal("12.0"), new BigDecimal("25.0"), observacaoUnica);
+        condicaoClimaticaDAO.inserir(cond);
+        CondicaoClimatica encontrada = condicaoClimaticaDAO.buscaPorId(cond.getId_condicao_climatica());
+        Assertions.assertNotNull(encontrada);
+        Assertions.assertEquals(observacaoUnica, encontrada.getObservacoes());
+        encontrada.setObservacoes(gerarNomeUnico("Observação Atualizada"));
+        condicaoClimaticaDAO.atualizar(encontrada);
+        CondicaoClimatica atualizada = condicaoClimaticaDAO.buscaPorId(cond.getId_condicao_climatica());
+        Assertions.assertEquals(encontrada.getObservacoes(), atualizada.getObservacoes());
+        condicaoClimaticaDAO.deletar(cond.getId_condicao_climatica());
+        Assertions.assertNull(condicaoClimaticaDAO.buscaPorId(cond.getId_condicao_climatica()));
+        safraDAO.deletar(safra.getId_safra());
+        variedadeCulturaDAO.deletar(variedade.getId_variedade_cultura());
+        culturaDAO.deletar(cultura.getId_cultura());
+        talhaoDAO.deletar(prop.getId(), talhao.getId_talhao());
+        propriedadeDAO.deletar(prop.getId());
+    }
+} 

--- a/docs/sivap
+++ b/docs/sivap
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS propriedade(
 );
 
 CREATE TABLE IF NOT EXISTS produtor_propriedade(
-	cpf_produtor_rural BIGINT, 
+	cpf_produtor_rural VARCHAR(11), 
 	id_propriedade INT,
 
 	CONSTRAINT pk_produtor_propriedade PRIMARY KEY (cpf_produtor_rural, id_propriedade),


### PR DESCRIPTION
### Descrição

- Renomeadas as colunas da tabela e métodos relacionados à classe `Cultura` para `nome_cultura` e `id_cultura`.
- Atualizados os métodos correspondentes na classe `Cultura`.
- Modificada a lógica de inserção na classe `PgTalhaoDAO` para buscar o próximo ID disponível antes de inserir um novo talhão.
- Agora, o `id` do talhão é serial, porém apenas dentro de uma mesma propriedade.

### Motivação

Essas alterações visam padronizar a nomenclatura das colunas e métodos, além de garantir a correta inserção de novos talhões no banco de dados, respeitando a serialização do `id` do talhão por propriedade.